### PR TITLE
v1.0.1: Fix Defaults and Invalidate Resource Locators for Scope and Collection when their dependency changed

### DIFF
--- a/nodes/Couchbase/CouchbaseProperties.ts
+++ b/nodes/Couchbase/CouchbaseProperties.ts
@@ -2,6 +2,7 @@ import type {
 	IDisplayOptions,
 	INodeProperties,
 	INodePropertyMode,
+	INodePropertyTypeOptions,
 	NodePropertyTypes,
 } from 'n8n-workflow';
 
@@ -75,6 +76,7 @@ const createFieldWithVaryingRequirements = (
 		conditions: DisplayCondition;
 		required: boolean;
 		options?: FieldOptions;
+		typeOptions?: INodePropertyTypeOptions;
 		modes?: ResourceLocatorMode[];
 	}[],
 ): INodeProperties[] => {
@@ -88,6 +90,7 @@ const createFieldWithVaryingRequirements = (
 			displayOptions: showFor(group.conditions),
 			description: group.options?.description || '',
 			placeholder: group.options?.placeholder || '',
+			typeOptions: group.typeOptions || {},
 			// Default is required in INodeProperties
 			default: group.options?.default !== undefined ? group.options.default : '',
 		};
@@ -327,6 +330,7 @@ export const nodeProperties: INodeProperties[] = [
 			},
 		],
 	),
+
 	...createFieldWithVaryingRequirements(
 		'Couchbase Scope',
 		'couchbaseScope',
@@ -345,6 +349,9 @@ export const nodeProperties: INodeProperties[] = [
 				required: true,
 				options: {
 					description: 'The Couchbase scope to use',
+				},
+				typeOptions: {
+					loadOptionsDependsOn: ['couchbaseBucket.value'],
 				},
 				modes: [
 					{
@@ -372,6 +379,9 @@ export const nodeProperties: INodeProperties[] = [
 				options: {
 					description: 'The Couchbase scope to use (optional for this operation)',
 				},
+				typeOptions: {
+					loadOptionsDependsOn: ['couchbaseBucket.value'],
+				},
 				modes: [
 					{
 						displayName: 'From List',
@@ -391,6 +401,7 @@ export const nodeProperties: INodeProperties[] = [
 			},
 		],
 	),
+
 	{
 		displayName: 'Couchbase Collection',
 		name: 'couchbaseCollection',
@@ -401,6 +412,9 @@ export const nodeProperties: INodeProperties[] = [
 			resource: RESOURCE.DOCUMENT,
 			operation: [DOCUMENT_OPS.CREATE, DOCUMENT_OPS.READ, DOCUMENT_OPS.UPSERT, DOCUMENT_OPS.DELETE],
 		}),
+		typeOptions: {
+			loadOptionsDependsOn: ['couchbaseBucket.value', 'couchbaseScope.value'],
+		},
 		modes: [
 			{
 				displayName: 'From List',

--- a/nodes/Couchbase/CouchbaseProperties.ts
+++ b/nodes/Couchbase/CouchbaseProperties.ts
@@ -516,7 +516,7 @@ export const nodeProperties: INodeProperties[] = [
 			resource: RESOURCE.SEARCH,
 			operation: [SEARCH_OPS.RETRIEVE],
 		}),
-		default: 'travel-sample.inventory.test-ts-fts',
+		default: '',
 		placeholder: 'bucket.scope.indexName',
 		description: 'Name of the search index to query',
 	},


### PR DESCRIPTION
1. Remove dangling default for Index Name
2. Invalidate Scope/Collection RL when the Bucket and/or Scope has changed, so they can be re-loaded under the new context