### PR TITLE
v1.1.3: Fixing vector store node path (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-couchbase",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Community node for using Couchbase Key-Value, Query, and Full-Text Search with n8n.",
   "keywords": [
     "n8n-community-node-package"
@@ -41,7 +41,7 @@
     ],
     "nodes": [
       "dist/nodes/Couchbase/Couchbase.node.js",
-      "dist/nodes/Couchbase/vector_store/VectorStoreCouchbaseSearch/VectorStoreCouchbaseSearch.node.js"
+      "dist/nodes/vector_store/VectorStoreCouchbaseSearch/VectorStoreCouchbaseSearch.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
`v1.1.2` of [n8n-nodes-couchbase](https://www.npmjs.com/package/n8n-nodes-couchbase) includes a very minor bug fix to ensure installation succeeds.

Changes include:

🛠️ Fix to the node path in package.json to ensure the path resolves on installation