### PR TITLE
v1.1.4: Require `n8n-workflow: ^1.85.0` to ensure class names resolve correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-couchbase",
   "version": "1.1.3",
-  "description": "Community node for using Couchbase Key-Value, Query, and Full-Text Search with n8n.",
+  "description": "Community nodes for using Couchbase Key-Value, Query, Full-Text Search, and Couchbase Search Vector Store with n8n.",
   "keywords": [
     "n8n-community-node-package"
   ],
@@ -23,7 +23,7 @@
   "main": "index.js",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "build": "tsc && gulp build:icons",
+    "build": "tsc && tsc-alias && gulp build:icons",
     "dev": "tsc --watch",
     "dev:ui": "nodemon -w nodes -w credentials -w utils --ext ts --exec 'tsc && tsc-alias && cd $HOME/.n8n/custom && COREPACK_ENABLE_STRICT=0 pnpm install && cd - && n8n'",
     "format": "prettier nodes credentials --write",
@@ -57,7 +57,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "n8n-workflow": "*"
+    "n8n-workflow": "^1.85.0"
   },
   "dependencies": {
     "@langchain/community": "^0.3.38",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         specifier: ^0.3.19
         version: 0.3.19(@langchain/core@0.3.43(openai@4.91.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2)))(axios@1.8.4)(encoding@0.1.13)(openai@4.91.0(encoding@0.1.13)(ws@8.18.1)(zod@3.24.2))(ws@8.18.1)
       n8n-workflow:
-        specifier: '*'
+        specifier: 1.85.0
         version: 1.85.0
       tmp-promise:
         specifier: ^3.0.3


### PR DESCRIPTION
`v1.1.4` of [n8n-nodes-couchbase](https://www.npmjs.com/package/n8n-nodes-couchbase) includes a very minor bug fix to ensure installation succeeds.

Changes include:

- 🔒 Require `n8n-workflow` version `1.85.0` to avoid an issue with the legacy `NodeConnectionTypes`
- ✍️ Update the description for npm