### PR TITLE
v1.3.2

### DIFF
--- a/credentials/CouchbaseApi.credentials.ts
+++ b/credentials/CouchbaseApi.credentials.ts
@@ -6,8 +6,8 @@ export class CouchbaseApi implements ICredentialType {
 	documentationUrl =
 		'https://github.com/Couchbase-Ecosystem/n8n-nodes-couchbase?tab=readme-ov-file#credentials';
 	icon: Icon = {
-		light: 'file:../nodes/Couchbase/couchbase.svg',
-		dark: 'file:../nodes/Couchbase/couchbase.dark.svg',
+		light: 'file:../nodes/icons/couchbase.svg',
+		dark: 'file:../nodes/icons/couchbase.dark.svg',
 	};
 	properties: INodeProperties[] = [
 		{


### PR DESCRIPTION
`v1.3.2` of [n8n-nodes-couchbase](https://www.npmjs.com/package/n8n-nodes-couchbase) fixes a schema compatiblility issue with vector search tools and fixes the path to the Couchbase icon for credentials. 

Changes include:
🔨 Fixes zod schema compatibility via runtime resolution
✨ Fixes path to Couchbase icon for credentials so the icon appears when editing `couchbaseAPI` credentials in the n8n UI